### PR TITLE
turbo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   ],
   "scripts": {
     "build": "yarn workspaces foreach --parallel --topological --verbose run build",
-    "dev:snap": "turbo run dev --filter=snap-beta...",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '!test/**' '**/*.yml' --ignore-path .gitignore",
     "start": "yarn workspaces foreach --parallel --interlaced --verbose run start",
+    "start:snap": "turbo run start --filter=snap-beta...",
     "test": "yarn workspaces foreach --exclude @galactica-net/zk-certificates -vp run test"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "yarn workspaces foreach --parallel --topological --verbose run build",
+    "dev:snap": "turbo run dev --filter=snap-beta...",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",

--- a/packages/galactica-types/package.json
+++ b/packages/galactica-types/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc",
     "debug": "eslint --print-config .eslintrc.js | grep -i sourceType",
-    "dev": "tsc --watch",
+    "start": "tsc --watch",
     "test": "echo \"No test specified\""
   },
   "devDependencies": {

--- a/packages/galactica-types/package.json
+++ b/packages/galactica-types/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc",
     "debug": "eslint --print-config .eslintrc.js | grep -i sourceType",
+    "dev": "tsc --watch",
     "test": "echo \"No test specified\""
   },
   "devDependencies": {

--- a/packages/snap-api/package.json
+++ b/packages/snap-api/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsup --dts",
-    "dev": "tsup --watch",
+    "start": "tsup --watch",
     "test": "echo \"No test specified\""
   },
   "dependencies": {

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -18,6 +18,7 @@
     "build:clean": "yarn clean && yarn build",
     "build:website": "node ./scripts/build-website.js",
     "clean": "rimraf dist",
+    "dev": "mm-snap watch",
     "eval:snap": "mm-snap eval -b dist/bundle.js --verboseErrors",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
@@ -25,7 +26,6 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
     "proofPrep": "ts-node src/scripts/proofGenerationPrep.ts \"$@\"",
     "serve": "mm-snap serve",
-    "start": "mm-snap watch",
     "test": "yarn run test:unit",
     "test:unit": "mocha --colors -r ts-node/register \"test/*.test.ts\""
   },

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -18,7 +18,6 @@
     "build:clean": "yarn clean && yarn build",
     "build:website": "node ./scripts/build-website.js",
     "clean": "rimraf dist",
-    "dev": "mm-snap watch",
     "eval:snap": "mm-snap eval -b dist/bundle.js --verboseErrors",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
@@ -26,6 +25,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
     "proofPrep": "ts-node src/scripts/proofGenerationPrep.ts \"$@\"",
     "serve": "mm-snap serve",
+    "start": "mm-snap watch",
     "test": "yarn run test:unit",
     "test:unit": "mocha --colors -r ts-node/register \"test/*.test.ts\""
   },

--- a/packages/zk-certificates/package.json
+++ b/packages/zk-certificates/package.json
@@ -26,6 +26,7 @@
     "build": "tsup --dts",
     "buildZK": "hardhat smartCircuitBuild --verbose && hardhat compile && tsc",
     "compile": "hardhat smartCircuitBuild --verbose",
+    "dev": "tsup --watch",
     "recompile": "hardhat clean; rm -r circuits/build/*; hardhat smartCircuitBuild --verbose",
     "test": "hardhat smartCircuitBuild --verbose && hardhat test"
   },

--- a/packages/zk-certificates/package.json
+++ b/packages/zk-certificates/package.json
@@ -26,8 +26,8 @@
     "build": "tsup --dts",
     "buildZK": "hardhat smartCircuitBuild --verbose && hardhat compile && tsc",
     "compile": "hardhat smartCircuitBuild --verbose",
-    "dev": "tsup --watch",
     "recompile": "hardhat clean; rm -r circuits/build/*; hardhat smartCircuitBuild --verbose",
+    "start": "tsup --watch",
     "test": "hardhat smartCircuitBuild --verbose && hardhat test"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "lint": {},
+    "dev": {
+      "cache": false,
+      "persistent": true
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
       "outputs": ["dist/**"]
     },
     "lint": {},
-    "dev": {
+    "start": {
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
Why turbo
autorun depended project: 
```
# Build 'my-app' and its dependencies
turbo run dev --filter=my-app...

# Build 'my-app's dependencies, but not 'my-app' itself
turbo run dev --filter=my-app^...
```
run project without organization prefix
`turbo run build --filter=@galactica-net/snap-beta -> turbo run build --filter=snap-beta`

Now we have to look at deps of for example snap-beta. When we want to build it we have to build dependant projects (zkcertificate, galactica-types) beforehand.
with turbo we can just execute `turbo run build --filter=snap-beta...`