### PR TITLE
Snap: Hotfix using the right chain provider instead of the default

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galactica-net/snap",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A Metamask Snap for managing and using zkCertificates on the Galactica network.",
   "repository": {
     "type": "git",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A Metamask Snap for managing and using zkCertificates on the Galactica network.",
   "proposedName": "Galactica ZK Vault",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/Galactica-corp/galactica-snap.git"
   },
   "source": {
-    "shasum": "pbLWAZSSD6P4Sp0HieWZs/Ay3u3jFXttjH8wiSUCzFc=",
+    "shasum": "Qf2AILs2sOJggiV2xWdLfEuS/wkyaY/YeysZ6bqAMf0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Galactica-corp/galactica-snap.git"
   },
   "source": {
-    "shasum": "6QvYFT1O7B9ZzMuilTPVeJqgkAuBYW6qMx7qSwFVUXI=",
+    "shasum": "pbLWAZSSD6P4Sp0HieWZs/Ay3u3jFXttjH8wiSUCzFc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/merkleProofSelection.ts
+++ b/packages/snap/src/merkleProofSelection.ts
@@ -65,17 +65,13 @@ export async function getMerkleProof(
     zkCert.merkleProof.leafIndex = (zkCert.merkleProof as any).index;
   }
 
-  // console.log('snap debug', (await provider.getNetwork()).chainId);
-  // console.log('snap getting merkle proof', JSON.stringify(zkCert.registration), registryAddr);
   if (
     fromHexToDec(await registry.merkleRoot()) ===
     getMerkleRootFromProof(zkCert.merkleProof, poseidon)
   ) {
     // The merkle root is the same as the one in the zkCert, so we can just use the old one
-    // console.log("done same root");
     return zkCert.merkleProof;
   }
-  // console.log("done different root");
 
   // Because the registry is revocable, the merkle tree has probably changed since last time the zkCert was issued/used.
   // Therefore, we need to fetch the merkle proof from the node or regenerate the tree to calculate it.

--- a/packages/snap/src/merkleProofSelection.ts
+++ b/packages/snap/src/merkleProofSelection.ts
@@ -12,7 +12,7 @@ import type { BaseProvider } from '@metamask/providers';
 import { buildPoseidon } from 'circomlibjs';
 import { Contract, BrowserProvider } from 'ethers';
 
-import { fetchWithTimeout } from './utils';
+import { fetchWithTimeout, switchChain } from './utils';
 
 const MERKLE_PROOF_SERVICE_PATH = 'merkle/proof/';
 
@@ -36,6 +36,7 @@ export async function getMerkleProof(
     return zkCert.merkleProof;
   }
 
+  await switchChain(zkCert.registration.chainID, ethereum);
   const provider = new BrowserProvider(ethereum);
   const registry = new Contract(
     registryAddr,
@@ -64,13 +65,17 @@ export async function getMerkleProof(
     zkCert.merkleProof.leafIndex = (zkCert.merkleProof as any).index;
   }
 
+  // console.log('snap debug', (await provider.getNetwork()).chainId);
+  // console.log('snap getting merkle proof', JSON.stringify(zkCert.registration), registryAddr);
   if (
     fromHexToDec(await registry.merkleRoot()) ===
     getMerkleRootFromProof(zkCert.merkleProof, poseidon)
   ) {
     // The merkle root is the same as the one in the zkCert, so we can just use the old one
+    // console.log("done same root");
     return zkCert.merkleProof;
   }
+  // console.log("done different root");
 
   // Because the registry is revocable, the merkle tree has probably changed since last time the zkCert was issued/used.
   // Therefore, we need to fetch the merkle proof from the node or regenerate the tree to calculate it.

--- a/packages/snap/src/utils.ts
+++ b/packages/snap/src/utils.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import type { BaseProvider } from '@metamask/providers';
+
 /**
  * Fetch with configurable timeout.
  * @param resource - URL to fetch from.
@@ -26,4 +28,16 @@ export async function fetchWithTimeout(resource: string, options: any = {}) {
  */
 export function stripURLProtocol(url: string): string {
   return url.replace(/(^\w+:|^)\/\//u, '');
+}
+
+/**
+ * Set the active Ethereum chain for the Snap.
+ * @param chainId - The chain ID to switch to.
+ * @param ethereum - Ethereum provider to switch the chain for.
+ */
+export async function switchChain(chainId: number, ethereum: BaseProvider) {
+  await ethereum.request({
+    method: 'wallet_switchEthereumChain',
+    params: [{ chainId: `0x${chainId.toString(16)}` }],
+  });
 }

--- a/packages/snap/test/wallet.mock.ts
+++ b/packages/snap/test/wallet.mock.ts
@@ -68,6 +68,7 @@ class EthereumMock extends ProviderMock {
     web3_clientVersion: stub(),
     eth_chainId: stub(),
     eth_call: stub(),
+    wallet_switchEthereumChain: stub(),
   };
   /* eslint-enable @typescript-eslint/naming-convention */
 


### PR DESCRIPTION
Somehow the default provider for snaps in Metamask stable changed. It is no longer the chain selected inside metamask, but Ethereum.
This broke proof generation in our stable snap version.
This hotfix specifically selects the chain instead of relying on the default.