### PR TITLE
Fix punycode deprecation warnings

### DIFF
--- a/packages/galactica-dapp/package.json
+++ b/packages/galactica-dapp/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=--no-deprecation BROWSERSLIST_IGNORE_OLD_DATA=1 GATSBY_TELEMETRY_DISABLED=1 gatsby build",
+    "build": "cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby build",
     "clean": "rimraf build",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",

--- a/packages/galactica-passport-poc/package.json
+++ b/packages/galactica-passport-poc/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=--no-deprecation BROWSERSLIST_IGNORE_OLD_DATA=1 GATSBY_TELEMETRY_DISABLED=1 gatsby build",
+    "build": "cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby build",
     "clean": "rimraf build",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",


### PR DESCRIPTION
Fix build deprecation warnings in test front-end about punycode and update Node.js version to resolve `yarn build` issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-400bdda4-77ce-4f69-b11f-2762fb14c0dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-400bdda4-77ce-4f69-b11f-2762fb14c0dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

