### PR TITLE
Fix/snap guardian info network

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galactica-net/snap",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Metamask Snap for managing and using zkCertificates on the Galactica network.",
   "repository": {
     "type": "git",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Metamask Snap for managing and using zkCertificates on the Galactica network.",
   "proposedName": "Galactica ZK Vault",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/Galactica-corp/galactica-snap.git"
   },
   "source": {
-    "shasum": "Q2AaPpeWKRY9bVboSZ03WfRTUb3oRDtebqzX89LbiX4=",
+    "shasum": "AHgbUp1j76tTsoLLDTm3l3A+y0+qrYtGr3gCU+H/zHg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/utils/getGuardianInfo.ts
+++ b/packages/snap/src/utils/getGuardianInfo.ts
@@ -9,6 +9,8 @@ import {
 import type { SnapsEthereumProvider } from '@metamask/snaps-sdk';
 import { BrowserProvider, Contract } from 'ethers';
 
+import { switchChain } from './utils';
+
 /**
  *
  * @param cert - Zk Certificate
@@ -20,6 +22,9 @@ export async function getGuardianInfo(
   ethereum: SnapsEthereumProvider,
 ) {
   try {
+    // we can only find the guardian info on the chain the certificate is issued on
+    await switchChain(cert.registration.chainID, ethereum);
+
     const provider = new BrowserProvider(ethereum);
     const kycRecordRegistryContract = new Contract(
       cert.registration.address,


### PR DESCRIPTION
On mainnet with snap 1.02 for stable metamask we get the following error when importing a Twitter certificate:
```
index.html:9130 Error#2: missing revert data (action="call", data=null, reason=null, transaction={ "data": "0x4232a3c3", "to": "0xAEb3403CAecc610be3130C8d6c152F472677514f" }, invocation=null, revert=null, code=CALL_EXCEPTION, version=6.14.3)
```
This looks like the snap is calling the right function and address on the wrong chain.
We found it here and forgot to fix it: https://github.com/Galactica-corp/galactica-monorepo/pull/95#discussion_r2367324595

Stragely, I can not reproduce the issue with MM Flask, even after reinstalling it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch to the certificate’s chain before querying guardian info, and bump Snap version to 1.0.3 with updated manifest shasum.
> 
> - **Snap logic**:
>   - In `packages/snap/src/utils/getGuardianInfo.ts`, ensure network is correct by calling `switchChain(cert.registration.chainID, ethereum)` before contract reads.
> - **Release/versioning**:
>   - Bump `@galactica-net/snap` to `1.0.3` in `packages/snap/package.json` and `snap.manifest.json`.
>   - Update `snap.manifest.json` `source.shasum` to reflect new build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1678a0c69e2df210fb66869bec52db44f5eb7de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->