### PR TITLE
fix: Ensure consistent type-based conversion for number fields to match Go implementation

### DIFF
--- a/packages/galactica-types/schema/certificate_content/kyc.json
+++ b/packages/galactica-types/schema/certificate_content/kyc.json
@@ -41,7 +41,7 @@
       "description": "The citizenship of the individual as an ISO 3166-1 alpha-3 country code."
     },
     "verificationLevel": {
-      "type": "number",
+      "type": "integer",
       "enum": [0, 1, 2],
       "description": "The level of KYC verification achieved.",
       "default": 0

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Galactica-corp/galactica-snap.git"
   },
   "source": {
-    "shasum": "XaEBlh/YVI6E30VRvEUTUcKv26O7NWn5hbV5zP2Tz2k=",
+    "shasum": "Bunc/kC9Sr3OtfQw6fDFnyQSGw5agaSY+eR9kzN63ac=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/zk-certificates/ignition/modules/zkCertRegistries/GIP8.m.ts
+++ b/packages/zk-certificates/ignition/modules/zkCertRegistries/GIP8.m.ts
@@ -1,0 +1,42 @@
+// This setup uses Hardhat Ignition to manage smart contract deployments.
+// Learn more about it at https://hardhat.org/ignition
+
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+import poseidonModule from '../Poseidon.m';
+
+const Gip8ZkCertRegistryModule = buildModule(
+  'Gip8ZkCertRegistryModule',
+  (module) => {
+    const { poseidon } = module.useModule(poseidonModule);
+
+    const guardianRegistryDescription = module.getParameter(
+      'guardianRegistryDescription',
+      'Blum Guardian Registry',
+    );
+
+    const guardianRegistry = module.contract('GuardianRegistry', [
+      guardianRegistryDescription,
+    ]);
+
+    const merkleDepth = module.getParameter('merkleDepth', 32);
+    const zkCertRegistryDescription = module.getParameter(
+      'zkCertRegistryDescription',
+      'Blum ZkCertificate Registry',
+    );
+
+    const zkCertRegistry = module.contract(
+      'ZkCertificateRegistry',
+      [guardianRegistry, merkleDepth, zkCertRegistryDescription],
+      {
+        libraries: {
+          PoseidonT3: poseidon,
+        },
+      },
+    );
+
+    return { guardianRegistry, zkCertRegistry };
+  },
+);
+
+export default Gip8ZkCertRegistryModule;

--- a/packages/zk-certificates/lib/zkCertificateDataProcessing.ts
+++ b/packages/zk-certificates/lib/zkCertificateDataProcessing.ts
@@ -73,10 +73,8 @@ export function prepareContentForCircuit<
       // Check if the field type is 'number' in the schema (for float64 handling)
       // JSON Schema uses 'number' for floats and 'integer' for integers
       const fieldType = schemaProperties[field]?.type;
-      if (fieldType === 'number' && !Number.isInteger(sourceData)) {
-        // Only apply float conversion if it's actually a decimal number
+      if (fieldType === 'number') {
         // Convert float64 to big integer with 18 decimal places for blockchain compatibility
-        // This matches the Go implementation's scoreToFixedPoint function
         resValue = floatToBigInt(sourceData, 18);
       } else {
         // Integer type ('integer' in schema) or whole number, can be passed as is


### PR DESCRIPTION
Removes the `Number.isInteger()` check that was causing inconsistent behavior in certificate field conversion. 
All schema fields with `type: "number"` now consistently apply 10^18 scaling, matching the Go implementation's `decimal.Decimal` behavior.